### PR TITLE
Await network after click

### DIFF
--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -6,7 +6,6 @@ export const defaults = {
   headless: true,
   waitForNavigation: true,
   waitForSelectorOnClick: true,
-  // TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-65e71fd55e20dbbed86374441613e73a6fab098d4b13ea02b056f3afdd4a11eaR9
   waitForNetworkIdleAfterClick: true,
   blankLinesBetweenBlocks: true,
   dataAttribute: '',
@@ -195,13 +194,6 @@ export default class BaseGenerator {
         value: `await ${this._frame}.click('${selector}')`,
       })
     }
-    // TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-65e71fd55e20dbbed86374441613e73a6fab098d4b13ea02b056f3afdd4a11eaR150-R155
-    if (this._options.waitForNetworkIdleAfterClick) {
-      block.addLine({
-        type: eventsToRecord.CLICK,
-        value: `await ${this._frame}.waitForNetworkIdle()`,
-      })
-    }
     return block
   }
 
@@ -212,7 +204,6 @@ export default class BaseGenerator {
     })
   }
 
-  // TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-65e71fd55e20dbbed86374441613e73a6fab098d4b13ea02b056f3afdd4a11eaR166-R179
   _handleGoto(href) {
     const block = new Block(this._frameId)
     block.addLine({

--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -6,6 +6,8 @@ export const defaults = {
   headless: true,
   waitForNavigation: true,
   waitForSelectorOnClick: true,
+  // TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-65e71fd55e20dbbed86374441613e73a6fab098d4b13ea02b056f3afdd4a11eaR9
+  waitForNetworkIdleAfterClick: true,
   blankLinesBetweenBlocks: true,
   dataAttribute: '',
   showPlaywrightFirst: true,
@@ -193,6 +195,13 @@ export default class BaseGenerator {
         value: `await ${this._frame}.click('${selector}')`,
       })
     }
+    // TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-65e71fd55e20dbbed86374441613e73a6fab098d4b13ea02b056f3afdd4a11eaR150-R155
+    if (this._options.waitForNetworkIdleAfterClick) {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `await ${this._frame}.waitForNetworkIdle()`,
+      })
+    }
     return block
   }
 
@@ -203,11 +212,20 @@ export default class BaseGenerator {
     })
   }
 
+  // TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-65e71fd55e20dbbed86374441613e73a6fab098d4b13ea02b056f3afdd4a11eaR166-R179
   _handleGoto(href) {
-    return new Block(this._frameId, {
+    const block = new Block(this._frameId)
+    block.addLine({
       type: headlessActions.GOTO,
       value: `await ${this._frame}.goto('${href}')`,
     })
+    if (this._options.waitForNetworkIdleAfterClick) {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `await ${this._frame}.waitForNetworkIdle()`,
+      })
+    }
+    return block
   }
 
   _handleViewport() {

--- a/src/modules/code-generator/playwright.js
+++ b/src/modules/code-generator/playwright.js
@@ -1,5 +1,5 @@
 import Block from '@/modules/code-generator/block'
-import { headlessActions } from '@/modules/code-generator/constants'
+import { headlessActions, eventsToRecord } from '@/modules/code-generator/constants'
 import BaseGenerator from '@/modules/code-generator/base-generator'
 
 const importPlaywright = `const { chromium } = require('playwright');\n`
@@ -34,6 +34,17 @@ export default class PlaywrightCodeGenerator extends BaseGenerator {
       type: headlessActions.VIEWPORT,
       value: `await ${this._frame}.setViewportSize({ width: ${width}, height: ${height} })`,
     })
+  }
+
+  _handleClick(selector, events, index) {
+    const block = super._handleClick(selector, events, index)
+    if (this._options.waitForNetworkIdleAfterClick) {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `await page.waitForLoadState('networkidle')`,
+      })
+    }
+    return block
   }
 
   _handleChange(selector, value) {

--- a/src/modules/code-generator/puppeteer.js
+++ b/src/modules/code-generator/puppeteer.js
@@ -1,5 +1,5 @@
 import Block from '@/modules/code-generator/block'
-import { headlessActions } from '@/modules/code-generator/constants'
+import { headlessActions, eventsToRecord } from '@/modules/code-generator/constants'
 import BaseGenerator from '@/modules/code-generator/base-generator'
 
 const importPuppeteer = `const puppeteer = require('puppeteer');\n`
@@ -27,6 +27,17 @@ export default class PuppeteerCodeGenerator extends BaseGenerator {
 
   generate(events) {
     return importPuppeteer + this._getHeader() + this._parseEvents(events) + this._getFooter()
+  }
+
+  _handleClick(selector, events, index) {
+    const block = super._handleClick(selector, events, index)
+    if (this._options.waitForNetworkIdleAfterClick) {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `await ${this._frame}.waitForNetworkIdle()`,
+      })
+    }
+    return block
   }
 
   _handleViewport(width, height) {

--- a/src/options/OptionsApp.vue
+++ b/src/options/OptionsApp.vue
@@ -84,7 +84,6 @@
           Add <code>waitForSelector</code> lines before every
           <code>page.click()</code>
         </Toggle>
-        <!-- TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-53c2041c5a87b1b74f6e34e5794e2774ba20516a3b47230d14d00d0b6e0eb200R87-R90 -->
         <Toggle v-model="options.code.waitForNetworkIdleAfterClick">
           Add <code>waitForNetwoorkIdle</code> lines after every <code>page.click()</code> or
           <code>page.goto()</code>

--- a/src/options/OptionsApp.vue
+++ b/src/options/OptionsApp.vue
@@ -84,6 +84,11 @@
           Add <code>waitForSelector</code> lines before every
           <code>page.click()</code>
         </Toggle>
+        <!-- TODO: Patched from https://github.com/RexSkz/headless-recorder/compare/main...UwSoftWare:await-network-after-click#diff-53c2041c5a87b1b74f6e34e5794e2774ba20516a3b47230d14d00d0b6e0eb200R87-R90 -->
+        <Toggle v-model="options.code.waitForNetworkIdleAfterClick">
+          Add <code>waitForNetwoorkIdle</code> lines after every <code>page.click()</code> or
+          <code>page.goto()</code>
+        </Toggle>
         <Toggle v-model="options.code.blankLinesBetweenBlocks">
           Add blank lines between code blocks
         </Toggle>


### PR DESCRIPTION
## Description

With a React application, a click doesn't always change the navigation. But in most cases will load some extra data. So add an option to wait after all network activity is done when clicking.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
